### PR TITLE
add cloud-init to DigitalOcean example for networking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,19 @@
         modules = [
           disko.nixosModules.disko
           { disko.devices.disk.disk1.device = "/dev/vda"; }
+          {
+            # do not use DHCP, as DigitalOcean provisions IPs using cloud-init
+            networking.useDHCP = nixpkgs.lib.mkForce false;
+
+            services.cloud-init = {
+              enable = true;
+              network.enable = true;
+
+              # not strictly needed, just for good measure 
+              datasource_list = [ "DigitalOcean" ];
+              datasource.DigitalOcean = { };
+            };
+          }
           ./configuration.nix
         ];
       };


### PR DESCRIPTION
Adds cloud-init to the DigitalOcean example, otherwise networking will not work. Fixes #5 .

Feel free to close PR and make a better one, if these changes do not fit this repo.