### PR TITLE
update digitalOcean cloud-init datasource options

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,10 @@
             services.cloud-init = {
               enable = true;
               network.enable = true;
-
-              # not strictly needed, just for good measure
-              datasource_list = [ "DigitalOcean" ];
-              datasource.DigitalOcean = { };
+              settings = {
+                datasource_list = [ "ConfigDrive" ];
+                datasource.ConfigDrive = { };
+              };
             };
           }
           ./configuration.nix


### PR DESCRIPTION
Unless I'm missing something, the `datasource` and `datasource_list` options don't exist for `cloud-init`, and cause the evaluation of the flake to fail. 
Tested with local flake eval and deploy to digital ocean.
See https://search.nixos.org/options?channel=unstable&query=cloud-init